### PR TITLE
Update title from 'Development' to 'Deployment'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl: /hsf-training-cicd-github
 carpentry: "hsf"
 
 # Overall title for pages.
-title: "Continuous Integration / Continuous Development (CI/CD) - Github Edition"
+title: "Continuous Integration / Continuous Deployment (CI/CD) - Github Edition"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"


### PR DESCRIPTION
Just noticed that the title should be Continuous Deployment (CD)

